### PR TITLE
Remove broken C developer link

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -13,7 +13,6 @@ title: 'Documentation'
 ## Gearman Internals
 
  * [Protocol Specification]({{ site.baseurl }}/protocol/)
- * [C Developer Documentation](http://gearman.org/docs/dev/)
 
 ## Language Bindings/Drivers/Frameworks
 


### PR DESCRIPTION
The page at gearman.org/docs/dev/ seems to be a 404 since roughly 2013.