### PR TITLE
Move Gearman chat room to matrix.org

### DIFF
--- a/communication/index.md
+++ b/communication/index.md
@@ -8,4 +8,4 @@ title: 'Communication'
 Most Gearman related communication happens on IRC or on the Google groups mailing list.
 
  * Google Group/Mailing List: [Gearman group on Google Groups](http://groups.google.com/group/gearman)
- * Matrix Chat: [Gearman](https://matrix.to/#/#gearman:spamaps.ems.host)
+ * Matrix Chat: [Gearman](https://matrix.to/#/#gearman:matrix.org)


### PR DESCRIPTION
ems.host has cancelled their personal plan so I won't host it on my own anymore.