### PR TITLE
Update links and other improvements

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -19,7 +19,7 @@ title: 'Documentation'
 Select your language -- cross links to download section which details all
 your options.
 
-[C]({{ site.baseurl }}/download/#libgearman_c),
+[C]({{ site.baseurl }}/gearmand/libgearman/),
 [C#/.NET]({{ site.baseurl }}/download/#c__net),
 [Go]({{ site.baseurl }}/download/#go),
 [Java]({{ site.baseurl }}/download/#java),

--- a/download/index.md
+++ b/download/index.md
@@ -52,12 +52,14 @@ This installs an executable called 'gearmand' (usually in /usr/local/bin).
 
 ## libgearman (C)
 
-The C client & worker API under BSD license that can be found in the same
-package as the C server. This library is closely tied with the gearmand C job
-server, sharing low level connection and protocol code.
+The C client & worker APIs are under the BSD license and can be found in the same
+package as the C server. This library is closely tied with the gearmand (C) job
+server, sharing low-level connection and protocol code.
 
- * [Gearman server and library](http://launchpad.net/gearmand/)
-   [(Source)](https://launchpad.net/gearmand)
+ * [Gearman server documentation]({{ site.baseurl }}/gearmand/)
+ * [libgearman library documentation]({{ site.baseurl }}/gearmand/libgearman/)
+ * [(Source repository)](https://github.com/gearman/gearmand)
+ * [(Download releases)](https://github.com/gearman/gearmand/releases)
 
 ## Shell
 

--- a/download/index.md
+++ b/download/index.md
@@ -24,7 +24,7 @@ statistics reporting are coming soon. This installs an executable called
 `gearmand` (usually in /usr/local/sbin). The C library, libgearman, is bundled
 in the same package.
 
- * [1.1.13 and later releases are on Github](https://github.com/gearman/gearmand/releases)
+ * [1.1.13 and later releases are on GitHub](https://github.com/gearman/gearmand/releases)
  * [pre 1.1.13 releases are on Launchpad](https://launchpad.net/gearmand)
 
 ## java-gearman-service (Java)
@@ -116,7 +116,7 @@ A PHP extension that wraps the libgearman C library.
 
 A pure PHP API that can be found as Net_Gearman on PEAR.
 
- * Net_Gearman at [PEAR](http://pear.php.net/package/Net_Gearman/) or [Github](https://github.com/brianlmoon/net_gearman)
+ * Net_Gearman at [PEAR](http://pear.php.net/package/Net_Gearman/) or [GitHub](https://github.com/brianlmoon/net_gearman)
 
 ### GearmanBundle
 

--- a/download/index.md
+++ b/download/index.md
@@ -58,8 +58,8 @@ server, sharing low-level connection and protocol code.
 
  * [Gearman server documentation]({{ site.baseurl }}/gearmand/)
  * [libgearman library documentation]({{ site.baseurl }}/gearmand/libgearman/)
- * [(Source repository)](https://github.com/gearman/gearmand)
- * [(Download releases)](https://github.com/gearman/gearmand/releases)
+ * [(Source)](https://github.com/gearman/gearmand)
+ * [(Download)](https://github.com/gearman/gearmand/releases)
 
 ## Shell
 
@@ -72,19 +72,21 @@ scripts. This is installed as an executable called `gearman` (usually in /usr/lo
 There are three Perl client implementations, two of which are Pure Perl and one
 which is a wrapper around the libgearman C library.
 
-### Gearman::XS
-
-A Perl module that wraps the libgearman C library. On CPAN under
-[Gearman::XS](http://search.cpan.org/dist/Gearman-XS/).
-
- * [Gearman::XS (0.12)](http://launchpad.net/gearmanxs/trunk/0.12/+download/Gearman-XS-0.12.tar.gz)
-
 ### Gearman::Client & ::Worker
 
 This pure Perl API can be found in CPAN under Gearman::Client
-and Gearman::Worker.
+and Gearman::Worker. It supports SSL and is quite robust and
+well maintained.
 
- *  [Perl modules on CPAN](http://search.cpan.org/dist/Gearman/)
+ *  [Perl modules on CPAN](https://metacpan.org/dist/Gearman)
+
+### Gearman::XS
+
+A Perl module that wraps the libgearman C library. On CPAN under
+[Gearman::XS](https://metacpan.org/dist/Gearman-XS). Has not been
+maintained in recent years.
+
+ * [Gearman::XS (0.12)](http://launchpad.net/gearmanxs/trunk/0.12/+download/Gearman-XS-0.12.tar.gz)
 
 ### AnyEvent::Gearman::Client & ::Worker
 

--- a/protocol/index.md
+++ b/protocol/index.md
@@ -5,7 +5,7 @@ title: 'Protocol'
 
 # Gearman Protocol
 
-This file is maintained in the [gearmand project on Github](https://github.com/gearman/gearmand/blob/master/PROTOCOL),
+This file is maintained in the [gearmand project on GitHub](https://github.com/gearman/gearmand/blob/master/PROTOCOL),
 so any modifications should be made there.
 
 {% highlight text %}

--- a/protocol/index.md
+++ b/protocol/index.md
@@ -174,7 +174,7 @@ SUBMIT_JOB_LOW, SUBMIT_JOB_LOW_BG
     server will then assign a job handle and respond with a JOB_CREATED
     packet.
 
-    If on of the BG versions is used, the client is not updated with
+    If one of the BG versions is used, the client is not updated with
     status or notified when the job has completed (it is detached).
 
     The Gearman job server queue is implemented with three levels:
@@ -336,7 +336,7 @@ CAN_DO_TIMEOUT
 
      Arguments:
      - NULL byte terminated Function name.
-     - Timeout value.
+     - Timeout value (in milliseconds).
 
 CANT_DO
 
@@ -561,6 +561,26 @@ status
     Arguments:
     - None.
 
+prioritystatus
+
+    This sends back a list of all registered functions. Next to each
+    function is the number of queued jobs that are not running, broken down
+    by priority, and the number of capable workers. The columns are tab
+    separated, and the list is terminated with a line containing
+    a single '.' (period). The format is:
+
+    FUNCTION\tHIGH-QUEUED\tNORMAL-QUEUED\tLOW-QUEUED\tAVAILABLE_WORKERS
+
+    Columns:
+    - Function name.
+    - Number of queued high priority jobs.
+    - Number of queued normal priority jobs.
+    - Number of queued low priority jobs.
+    - Available workers registered for this function.
+
+    Arguments:
+    - None.
+
 maxqueue
 
     This sets the maximum queue size for a function. If no size is
@@ -575,15 +595,6 @@ maxqueue
     - Optional maximum queue size (to apply one maximum at all priorities), or
       three optional maximum queue sizes (to enforce for high-, normal-, and
       low-priority job submissions).
-
-shutdown
-
-    Shutdown the server. If the optional "graceful" argument is used,
-    close the listening socket and let all existing connections
-    complete.
-
-    Arguments:
-    - Optional "graceful" mode.
 
 version
 


### PR DESCRIPTION
This pull request makes the following changes:

* Replaces "Github" with "GitHub" throughout.
* Updates the protocol page to match latest PROTOCOL document from gearmand 
GitHub repository.
* Updates the links for libgearman documentation and such (maybe addresses issue #18).
* Updates the links in the Perl section. Changes order of Perl modules to put the best maintained module first.

Kind of a "grab bag" of changes, but, whenever I start changing something, I find it difficult to stop!