### PR TITLE
Issue #24 Update the PHP examples and PHP extension API documentation

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -236,7 +236,7 @@ a string to the job server and print the return value.
 <?php
 $client= new GearmanClient();
 $client->addServer();
-print $client->do("reverse", "Hello World!");
+print $client->doNormal("reverse", "Hello World!");
 ?>
 {% endhighlight %}
 

--- a/index.md
+++ b/index.md
@@ -68,7 +68,7 @@ omitted for brevity):
 // Reverse Client Code
 $client = new GearmanClient();
 $client->addServer();
-print $client->do("reverse", "Hello World!");
+print $client->doNormal("reverse", "Hello World!");
 {% endhighlight %}
 
 This code initializes a client class, configures it to use a job server with

--- a/pages/gearman.txt
+++ b/pages/gearman.txt
@@ -25,7 +25,7 @@ We start off by writing a client application that is responsible for sending off
 # Reverse Client Code
 $client= new GearmanClient();
 $client->addServer();
-print $client->do("reverse", "Hello World!");
+print $client->doNormal("reverse", "Hello World!");
 </code>
 
 This code initializes a client class, configures it to use a job server with **add_server** (no arguments means use 127.0.0.1 with the default port), and then tells the client API to run the **"reverse"** function with the workload "Hello world!". The function name and arguments are completely arbitrary as far as Gearman is concerned, so you could send any data structure that is appropriate for your application (text or binary). At this point the Gearman client API will package up the job into a Gearman protocol packet and send it to the job server to find an appropriate worker that can run the **"reverse"** function. Let's now look at the worker code:

--- a/pages/gearman_php_extension.txt
+++ b/pages/gearman_php_extension.txt
@@ -60,7 +60,7 @@ $client->addServer("localhost", 4730);
 echo "Sending job\n";
  
 # Send reverse job
-$result = $client->do("reverse", "Hello!");
+$result = $client->doNormal("reverse", "Hello!");
 if ($result)
   echo "Success: $result\n";
 ?>

--- a/pages/getting_started.txt
+++ b/pages/getting_started.txt
@@ -175,7 +175,7 @@ The PHP client interface is similar to the worker. The following code will send 
 <?php
 $client= new GearmanClient();
 $client->addServer();
-print $client->do("reverse", "Hello World!");
+print $client->doNormal("reverse", "Hello World!");
 ?>
 </code>
 

--- a/pages/php_reference.txt
+++ b/pages/php_reference.txt
@@ -36,11 +36,11 @@ This list may include functions that are not implemented yet (see [[php reflecti
    * **addOptions(// $options //)** - Add options for a client object
    * **removeOptions(// $options //)** - Remove options for a client object
    * **addServer(// $host, $port //)** - Add a job server to a client. This goes into a list of servers than can be used to run tasks. No socket I/O happens here, it is just added to a list.
-   * **do(// $function_name, $workload, $unique //)** - Run a single task and return an allocated result.
+   * **doNormal(// $function_name, $workload, $unique //)** - Run a single task and return an allocated result.
    * **doHigh(// $function_name, $workload, $unique //)** - Run a high priority task and return an allocated result.
    * **doLow(// $function_name, $workload, $unique //)** - Run a low priority task and return an allocated result.
-   * **doJobHandle()** - Get the job handle for the running task. This should be used between repeated do() and doHigh() calls to get information.
-   * **doStatus()** - Get the status for the running task. This should be used between repeated do() and doHigh() calls to get information.
+   * **doJobHandle()** - Get the job handle for the running task. This should be used between repeated doNormal()/doHigh()/doLow() calls to get information.
+   * **doStatus()** - Get the status for the running task. This should be used between repeated doNormal()/doHigh()/doLow() calls to get information.
    * **doBackground(// $function_name, $workload, $unique //)** - Run a task in the background.
    * **doHighBackground(// $function_name, $workload, $unique //)** - Run a high priority task in the background
    * **doLowBackground(// $function_name, $workload, $unique //)** - Run a low priority task in the background.

--- a/php-client-libraries/extension/reflection/index.md
+++ b/php-client-libraries/extension/reflection/index.md
@@ -60,7 +60,6 @@ class GearmanClient {
   public function addServer($host, $port){}
   public function addServers($servers){}
   public function wait(){}
-  public function do($function_name, $workload, $unique = null){}
   public function doNormal($function_name, $workload, $unique = null){}
   public function doHigh($function_name, $workload, $unique = null){}
   public function doLow($function_name, $workload, $unique = null){}


### PR DESCRIPTION
This PR addresses issue #24. Apparently, the `do` method was dropped from the Gearman PHP extension at some point. There's just `doNormal` now. It's been like this for at least 4 years, according to the git history in the repository for the PHP extension.